### PR TITLE
Chain Of Custody refactoring [1]

### DIFF
--- a/server/es6/BlockChainVerifier.js
+++ b/server/es6/BlockChainVerifier.js
@@ -4,12 +4,12 @@ import { settingsHelper } from './SettingsHelper';
 class BlockChainVerifier {
 
     generateHash(jsonString) {
-        const hash = '0x' + crypto.createHash('sha256').update(jsonString).digest('hex');
-        return hash;
+        return crypto.createHash('sha256').update(jsonString).digest('hex');
     }
 
-    verifyBlockChain(stringifiedSlice, oneBcClient) {
-        return oneBcClient.verify(this.generateHash(stringifiedSlice));
+    verifyHash(hash, oneBcClient) {
+        if(hash.indexOf('0x') != 0) hash = '0x' + hash;
+        return oneBcClient.verify(hash);
     }
 }
 

--- a/server/es6/DBConnectionManager.js
+++ b/server/es6/DBConnectionManager.js
@@ -50,7 +50,7 @@ class DBConnectionManager {
                 console.log('Creating Index/Collection for Transactions');
                 if (collinfo) {
                     me.state.db.collection(collinfo.name).createIndex({
-                        "transactionSlices.businessTransactions.btId": 1
+                        "transactionSlices.businessTransactionIds": 1
                     });
                     me.state.db.collection(collinfo.name).createIndex({
                         tnxId: 1
@@ -62,7 +62,7 @@ class DBConnectionManager {
                             console.error("error while creating collection");
                         } else {
                             collection.createIndex({
-                                "transactionSlices.businessTransactions.btId": 1
+                                "transactionSlices.businessTransactionIds": 1
                             });
                             collection.createIndex({
                                 tnxId: 1
@@ -84,8 +84,8 @@ class DBConnectionManager {
                         } else {
                             console.log("Settings collection created successfully.")
                         }
-                    }) 
-                }  
+                    })
+                }
             });
     }
 
@@ -108,7 +108,7 @@ class DBConnectionManager {
                 }
             }).catch(function (err) {
                 console.error("While setting mode in Settings collection" + err);
-                
+
             });
         })
     }

--- a/server/es6/ReceiveTransactionsTask.js
+++ b/server/es6/ReceiveTransactionsTask.js
@@ -3,6 +3,7 @@ import {transactionConsumer} from './TransactionConsumer';
 import {dbconnectionManager} from './DBConnectionManager';
 import {settingsHelper} from './SettingsHelper';
 import {backChainUtil} from  './BackChainUtil';
+import { blockChainVerifier } from './BlockChainVerifier';
 
 class ReceiveTransactionsTask {
     constructor() {
@@ -10,6 +11,47 @@ class ReceiveTransactionsTask {
     }
 
     callGetMessages(authenticationToken, chainOfCustodyUrl, callback) {
+        let result = {
+            "success":true,
+            "hasMorePages":false,
+            "transactionMessages":[
+               {
+                  "date":1516724694000,
+                  "sequence":1,
+                  "transactionSliceHash":"9d964e86f14cfcaec65818c76e1d755bba9581506b2e60cbd9ec86b6b4e99984",
+                  "transactionSliceString":"{\"businessTransactions\":[{\"LastModifiedDate\":{\"date\":\"2018-01-23T16:24:53\",\"tzId\":\"America/New_York\",\"tzCode\":\"EST\"},\"btid\":\"b912abcd3885fee4d16356665ddea6a665bf6bedd05a06d6c2c4b193c4d837c6\",\"ModelLevelType\":\"PTA.TestModel\",\"PtxVersion\":1,\"btref\":\"http://sdurkin:80/oms~PTA.TestModel~aaaabbbb~100\",\"ValueChainId\":100,\"TestModelKey\":\"aaaabbbb\",\"ActionName\":\"PTA.CreateTestModel\",\"Active\":true,\"LastModifiedUser\":\"ScottRepAnalyst\"}],\"enterprise\":\"ProgressiveRetailer\",\"type\":\"Enterprise\"}",
+                  "id":"a15e27c51be1ec0b1bbcebcea3578b9dd3bd131f54cf66262a046a15c264b096",
+                  "type": "Enterprise",
+                  "enterprise": "ProgressiveRetailer",
+                  "businessTransactionIds": ["b912abcd3885fee4d16356665ddea6a665bf6bedd05a06d6c2c4b193c4d837c6"]
+               },
+               {
+                  "date":1516724694000,
+                  "sequence":2,
+                  "transactionSliceHash":"e54bc1e0e28b4232ec8c1ac8a512461793f8470d65084bd2164896785f073c81",
+                  "transactionSliceString":"{\"businessTransactions\":[{\"LastModifiedDate\":{\"date\":\"2018-01-23T16:24:53\",\"tzId\":\"America/New_York\",\"tzCode\":\"EST\"},\"btid\":\"b912abcd3885fee4d16356665ddea6a665bf6bedd05a06d6c2c4b193c4d837c6\",\"ModelLevelType\":\"PTA.TestModel\",\"PtxVersion\":1,\"btref\":\"http://sdurkin:80/oms~PTA.TestModel~aaaabbbb~100\",\"ValueChainId\":100,\"TestModelKey\":\"aaaabbbb\",\"ActionName\":\"PTA.CreateTestModel\",\"Active\":true,\"LastModifiedUser\":\"ScottRepAnalyst\"}],\"type\":\"Intersection\",\"enterprises\":[\"Carrier A\",\"ProgressiveRetailer\"]}",
+                  "id":"a15e27c51be1ec0b1bbcebcea3578b9dd3bd131f54cf66262a046a15c264b096",
+                  "type": "Intersection",
+                  "enterprises": [ "ProgressiveRetailer", "CarrierA" ],
+                  "businessTransactionIds": ["b912abcd3885fee4d16356665ddea6a665bf6bedd05a06d6c2c4b193c4d837c6"]
+               },
+               {
+                "date":1516724694000,
+                "sequence":3,
+                "transactionSliceHash":"e54bc1e0e28b4232ec8c1ac8a512461793f8470d65084bd2164896785f073c81",
+                "transactionSliceString":"{\"businessTransactions\":[{\"LastModifiedDate\":{\"date\":\"2018-01-23T16:24:53\",\"tzId\":\"America/New_York\",\"tzCode\":\"EST\"},\"btid\":\"b912abcd3885fee4d16356665ddea6a665bf6bedd05a06d6c2c4b193c4d837c6\",\"ModelLevelType\":\"PTA.TestModel\",\"PtxVersion\":1,\"btref\":\"http://sdurkin:80/oms~PTA.TestModel~aaaabbbb~100\",\"ValueChainId\":100,\"TestModelKey\":\"aaaabbbb\",\"ActionName\":\"PTA.CreateTestModel\",\"Active\":false,\"LastModifiedUser\":\"ScottRepAnalyst\"}],\"type\":\"Enterprise\",\"enterprise\":\"ProgressiveRetailer\"]}",
+                "id":"a15e27c51be1ec0b1bbcebcea3578b9dd3bd131f54cf66262a046a15c264b096",
+                "type": "Enterprise",
+                "enterprise": "ProgressiveRetailer",
+                "businessTransactionIds": ["b912abcd3885fee4d16356665ddea6a665bf6bedd05a06d6c2c4b193c4d837c6"]
+             }
+           ]
+         };
+        if(result && result.transactionMessages) {
+            console.log("Received " + result.transactionMessages.length + " messages");
+        }
+        callback(null, result);
+        /*
         fetch(backChainUtil.returnValidURL(chainOfCustodyUrl + '/oms/rest/backchain/v1/consume?limitInKb=1024'), {
             method: 'get',
             headers: new Headers({
@@ -23,11 +65,12 @@ class ReceiveTransactionsTask {
         }).then(function(result) {
             if(result && result.transactionMessages) {
                 console.log("Received " + result.transactionMessages.length + " messages");
-            }            
+            }
             callback(null, result);
         }).catch(function (err) {
             callback(err, null);
         });
+        */
     }
 
     consumeTransactionMessages(authenticationToken, chainOfCustodyUrl, callback) {
@@ -48,14 +91,14 @@ class ReceiveTransactionsTask {
                     let hasMorePages = result.hasMorePages || false;
                     me.insertMessages(result.transactionMessages);
                     let lastSyncTimeInMillis = me.insertOrUpdateSettings(authenticationToken, chainOfCustodyUrl);
-    
+
                     if(hasMorePages) {
                         me.consumeTransactionMessages(authenticationToken, chainOfCustodyUrl);
                     }
                     if(typeof callback !== 'undefined') {
                         callback(null, {syncDone : true, authenticationToken: authenticationToken, chainOfCustodyUrl: chainOfCustodyUrl, lastSyncTimeInMillis: lastSyncTimeInMillis});
                     }
-                }                
+                }
             }
         });
     }
@@ -64,7 +107,7 @@ class ReceiveTransactionsTask {
         const me = this;
         settingsHelper.getApplicationSettings()
         .then(function(result) {
-            if(typeof result != 'undefined' && typeof result.chainOfCustidy != 'undefined' && 
+            if(typeof result != 'undefined' && typeof result.chainOfCustidy != 'undefined' &&
             typeof result.chainOfCustidy.authenticationToken != 'undefined' && typeof result.chainOfCustidy.chainOfCustodyUrl != 'undefined') {
                 console.info('Chain of Custody data will be synced every ' + config.syncDataIntervalInMillis + ' milliseconds');
                 setInterval(function(){
@@ -74,7 +117,7 @@ class ReceiveTransactionsTask {
         })
         .catch(function (err) {
             console.error("Application Settings can't be read: " + err);
-        });  
+        });
     }
 
     insertOrUpdateSettings(authenticationToken, chainOfCustodyUrl) {
@@ -88,8 +131,8 @@ class ReceiveTransactionsTask {
                 settingsCollection = result;
             }
             /* If the timer hasn't started yet, it's time to start. Only happens with a new instance*/
-            let startTheTimer = typeof settingsCollection.chainOfCustidy == 'undefined' || 
-            typeof settingsCollection.chainOfCustidy.chainOfCustodyUrl == 'undefined' || typeof settingsCollection.chainOfCustidy.authenticationToken == 'undefined'; 
+            let startTheTimer = typeof settingsCollection.chainOfCustidy == 'undefined' ||
+            typeof settingsCollection.chainOfCustidy.chainOfCustodyUrl == 'undefined' || typeof settingsCollection.chainOfCustidy.authenticationToken == 'undefined';
             let writeValue = null;
             if(settingsCollection) {
                 settingsCollection.chainOfCustidy = {
@@ -112,8 +155,6 @@ class ReceiveTransactionsTask {
 
             dbconnectionManager.getConnection().collection("Settings").updateOne({type: 'applicationSettings'}, {$set: writeValue}, { upsert: true }, function(err, res) {
                 if (err) {
-                    //throw err;
-                    //Error shouldn't bubble, we need to log and move on 
                     console.error(err);
                 }
                 else if(res) {
@@ -126,66 +167,100 @@ class ReceiveTransactionsTask {
         });
 
         return lastSyncTimeInMillis;
-    }    
+    }
 
     insertMessages(transMessages) {
-        const inMemoryTnx = {}; //To prevent race conditions, maintain and in memory object. If db returns null, we should look at in-memory to prevent override of db
+        const me = this;
+
+        // To prevent race conditions, maintain an in-memory object. If db
+        // returns null, we should look at in-memory object to prevent override of db.
+        const inMemoryTnx = {};
+
         settingsHelper.getSyncStatistics()
-        .then((syncStatistics) => {
-            syncStatistics = syncStatistics || 
-            {  
-                "earliestSyncDateInMillis": null,
-                "earliestSyncSequenceNo": null,
-                "latestSyncDateInMillis": null,
-                "latestSyncSequenceNo": null,
-                "gaps": []
+            .then((syncStatistics) => {
+                syncStatistics = syncStatistics || {
+                    "earliestSyncDateInMillis": null,
+                    "earliestSyncSequenceNo": null,
+                    "latestSyncDateInMillis": null,
+                    "latestSyncSequenceNo": null,
+                    "gaps": []
+                };
+
+                for (let i = 0; i < transMessages.length; i++) {
+                    me.insertMessage(transMessages[i], inMemoryTnx, syncStatistics);
+                }
+            })
+            .catch((err) => {
+                console.error("Error occurred while fetching transaction by tnxId [" + transMessage.id + "]" + err);
+                callback(err, null);
+            });
+
+    }
+
+    insertMessage(transMessage, inMemoryTnx, syncStatistics) {
+        const me = this;
+        dbconnectionManager.getConnection().collection('Transactions').findOne({
+            "id": transMessage.id
+        }).then((result) => {
+            let transactionInDb = result || inMemoryTnx[transMessage.id] || {
+                id: transMessage.id,
+                date: transMessage.date,
+                transactionSlices: [],
+
+                // Hashes received from Platform
+                transactionSliceHashes: [],
+
+                // Hashes generated by BCV from the serialized slice
+                trueTransactionSliceHashes: []
             };
-            for (let i = 0; i < transMessages.length; i++) {
-                let transMessage = transMessages[i]; 
-                //Need to have closure to make sure promise doesn't use the latest message in transMessages array.
-                //Take a look at https://stackoverflow.com/questions/31061516/how-to-pass-a-local-variable-to-a-promise-done-function
-                (function(txnMsg){
-                    dbconnectionManager.getConnection().collection('Transactions').findOne({
-                        "id": txnMsg.id
-                    }).then((result) => {
-                        let transactionInDb = result || inMemoryTnx[txnMsg.id] || 
-                        {
-                            id: txnMsg.id,
-                            transactionSlices: [],
-                            transactionSliceObjects: [],
-                            transactionSliceHashes: [],
-                            sequenceNos: []
-                        };
-                        if(transactionInDb.transactionSliceHashes.indexOf(txnMsg.transactionSliceHash) < 0) {
-                            settingsHelper.modifySyncStatsObject(syncStatistics, txnMsg); //This message is new so update db and stats
-                            settingsHelper.updateSyncStatistics(syncStatistics);
-                            transactionInDb.transactionSlices.push(txnMsg.transactionSliceString);
-                            transactionInDb.transactionSliceObjects.push(JSON.parse(txnMsg.transactionSliceString));
-                            transactionInDb.transactionSliceHashes.push(txnMsg.transactionSliceHash);
-                            transactionInDb.sequenceNos.push(txnMsg.sequence);
-                            inMemoryTnx[txnMsg.id] = transactionInDb;
-                            dbconnectionManager.getConnection().collection('Transactions').update(
-                                {
-                                    "id": transactionInDb.id
-                                },
-                                transactionInDb , {
-                                    upsert: true
-                                }
-                            )
-                        }                
-                    })
-                    .catch((err) => {
-                        console.error("Error occurred while fetching transaction by tnxId [" + txnMsg.id + "]" + err);
-                        callback(err, null);
-                    });
-                })(transMessage);                
+
+            console.log("Received " + transMessage.transactionSliceHash);
+            if(transactionInDb.transactionSliceHashes.indexOf(transMessage.transactionSliceHash) >= 0) {
+                console.log("Already in DB, skipping");
+                return;
             }
+
+            // This message is new, so update db and stats.
+            settingsHelper.modifySyncStatsObject(syncStatistics, transMessage);
+            settingsHelper.updateSyncStatistics(syncStatistics);
+
+            let sliceInDb = {};
+            let transactionSliceObj = JSON.parse(transMessage.transactionSliceString);
+            sliceInDb.businessTransactionIds = me.getBusinessTransactionIds(transactionSliceObj);
+            sliceInDb.sequence = transMessage.sequence;
+            sliceInDb.type = transactionSliceObj.type;
+            sliceInDb.enterprise = transactionSliceObj.enterprise;
+            sliceInDb.enterprises = transactionSliceObj.enterprises;
+            transactionInDb.transactionSlices.push(sliceInDb);
+
+            // TODO: save slice in GridFS, store payloadId in sliceInDb
+
+            transactionInDb.transactionSliceHashes.push(transMessage.transactionSliceHash);
+            let trueSliceHash = blockChainVerifier.generateHash(transMessage.transactionSliceString);
+            transactionInDb.trueTransactionSliceHashes.push(trueSliceHash);
+
+            inMemoryTnx[transMessage.id] = transactionInDb;
+
+            dbconnectionManager.getConnection().collection('Transactions').update(
+                {
+                    "id": transactionInDb.id
+                },
+                transactionInDb, {
+                    upsert: true
+                });
         })
         .catch((err) => {
             console.error("Error occurred while fetching transaction by tnxId [" + transMessage.id + "]" + err);
             callback(err, null);
         });
-        
+    }
+
+    getBusinessTransactionIds(obj) {
+        var businessTransactionIds = [];
+        for(let i = 0; i < obj.businessTransactions.length; i++) {
+            businessTransactionIds.push(obj.businessTransactions[i].btid);
+        }
+        return businessTransactionIds;
     }
 
 }

--- a/server/es6/SyncTransactionTaskHelper.js
+++ b/server/es6/SyncTransactionTaskHelper.js
@@ -8,14 +8,20 @@ import "isomorphic-fetch";
  Helper class contains synch related APIs
 */
 class SyncTransactionTaskHelper {
-    
+
         constructor() {}
 
         startSyncFromCertainDate(authenticationToken, startFromDate, chainOfCustodyUrl, callback) {
             let me = this;
             let dateAsString = moment(new Date(parseInt(startFromDate,10))).format('YYYYMMDD');
             console.log('sync start date: ' + dateAsString);
-            
+
+            let result = { "success": true, "entName": "ProgressiveRetailer" };
+            me.updatechainOfCustody(authenticationToken, chainOfCustodyUrl,result.entName, function(chainOfCustidy) {
+                chainOfCustidy.success = 'success';
+                callback(null, chainOfCustidy);
+            });
+            /*
             fetch(backChainUtil.returnValidURL(chainOfCustodyUrl + '/oms/rest/backchain/v1/reset?fromDate=' + dateAsString), {
                 method: 'get',
                 headers: new Headers({
@@ -35,6 +41,7 @@ class SyncTransactionTaskHelper {
                 console.log(err);
                 callback(err, null)
             });
+            */
         }
         updatechainOfCustody(authenticationToken, chainOfCustodyUrl,entName, callback) {
             dbconnectionManager.getConnection().collection('Settings').findOne({ type: 'applicationSettings' }, function (err, result) {
@@ -48,7 +55,7 @@ class SyncTransactionTaskHelper {
                         "chainOfCustodyUrl" : chainOfCustodyUrl,
                         "enterpriseName":entName
                     }
-                    
+
                     let resultSet = dbconnectionManager.getConnection().collection('Settings').updateOne({}, {$set: result}).then((resultSet) => {
                     if (resultSet.modifiedCount > 0) {
                             console.log("Settings updated successfully ");
@@ -73,7 +80,7 @@ class SyncTransactionTaskHelper {
                     callback(err, null);
                 });
         }
-    
+
         setLastSyncedDate(lastSyncedDateInMillis) {
             dbconnectionManager.getConnection().collection('Settings').findOne({ type: 'applicationSettings' }, function (err, result) {
                 if (err) {
@@ -92,7 +99,7 @@ class SyncTransactionTaskHelper {
                 }
 			})
         }
-    
+
         isInitialSyncDone(callback) {
             dbconnectionManager.getConnection().collection('Settings').findOne({type: 'applicationSettings'}).then((result) => {
                 if (result && result.chainOfCustidy && result.chainOfCustidy.lastSyncTimeInMillis) {

--- a/server/es6/bcv-app.jsx
+++ b/server/es6/bcv-app.jsx
@@ -6,6 +6,7 @@ import SearchByTransactionIdView from './components/SearchByTransactionIdView';
 import SetupView from './components/SetupView';
 import SyncStatisticsView from './components/SyncStatisticsView';
 import StartSyncView from './components/StartSyncView';
+import TrackAndVerifyView from './components/TrackAndVerifyView';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter, Route, Switch, Redirect} from 'react-router-dom';
@@ -30,11 +31,23 @@ const RoutedApp = () => (
   </BrowserRouter>
 );
 
-(function(){
-  BackChainActions.init(backChainStore);
-  })()
 
-ReactDOM.render(
-    <RoutedApp/>,
-    document.getElementById('root')
-);
+window.BackchainVerifyAPI = {
+    setup: (renderTo, options) => {
+        BackChainActions.init(backChainStore);
+
+        options = options || {};
+        const componentToRender = options.showOnlyVerifyView
+            ? <TrackAndVerifyView store={backChainStore} hideProgressBar />
+            : <RoutedApp/>;
+
+        if (typeof renderTo == 'string') {
+            renderTo = $(renderTo)[0];
+        }
+        ReactDOM.render(componentToRender, renderTo);
+    },
+
+    loadTransactions: (transactions) => {
+        BackChainActions.loadTransactions(transactions);
+    }
+};

--- a/server/es6/components/SearchByTextView.jsx
+++ b/server/es6/components/SearchByTextView.jsx
@@ -7,13 +7,13 @@ import { TablePagination } from 'react-pagination-table';
 import HeaderView from "./HeaderView";
 const Header = ['',"Model Type", "Business Transaction ID" ];
 
- 
+
 @observer export default class SearchByTextView extends React.Component {
     constructor(props) {
 		super(props);
 		this.state = {redirect:false,transaction: {},verifyDisabled:true};
 	}
-	
+
 	businessTransactionTextSearch(event){
 		this.props.store.businessTransactionTextSearch = event.target.value.trim();
 		if (this.props.store.businessTransactionTextSearch.length > 0 && event.charCode  == 13) {
@@ -31,7 +31,7 @@ const Header = ['',"Model Type", "Business Transaction ID" ];
         let me = this;
         let searchText =  me.props.store.businessTransactionTextSearch;
         let uri = '/getTransactionByText/'+searchText;
-        
+
 		fetch(uri, {method: 'GET'}).then(function(response) {
 			return response.json();
 		}, function(error) {
@@ -40,7 +40,7 @@ const Header = ['',"Model Type", "Business Transaction ID" ];
             me.setState({ transaction: result});
   		})
 	}
-	
+
 	toggleCheckbox = evt => {
 		this.props.store.businessTransactionIdSearch=evt.target.value;
 		this.props.store.searchCriteria = 'btId';
@@ -50,8 +50,8 @@ const Header = ['',"Model Type", "Business Transaction ID" ];
 	componentDidMount() {
 		BackChainActions.processApplicationSettings();
 	}
-	
-	render() { 
+
+	render() {
            if (this.props.store.isInitialSetupDone == null) {
                 return null;
 			} else if (this.props.store.isInitialSetupDone === false) {
@@ -119,13 +119,13 @@ const Header = ['',"Model Type", "Business Transaction ID" ];
 
 			};
 
-			
+
 			let data=[];
 			let transactionsToVerify = [];
 			if (this.state.transaction.result) {
 				for (let i = 0; i < this.state.transaction.result.length; i++) {
 					let transaction = this.state.transaction.result[i];
-					let transactionSlices = transaction.transactionSliceObjects;
+					let transactionSlices = transaction.transactionSlices;
 					for (let j = 0; j < transactionSlices.length; j++) {
 						let businessTransactions = transactionSlices[j].businessTransactions;
 						for(let k= 0; k < businessTransactions.length; k++) {
@@ -153,21 +153,21 @@ const Header = ['',"Model Type", "Business Transaction ID" ];
 			let tablePanel = '';
 			if(this.state.transaction.result) {
 				tablePanel = (<div style={ {paddingLeft: '22px'}} >
-				
-				<TablePagination 
-					headers={ Header } 
-					data={ data } 
+
+				<TablePagination
+					headers={ Header }
+					data={ data }
 					columns="radio.modelLevelType.btId"
 					perPageItemCount={ 5 }
-					totalCount={ data.length } 
+					totalCount={ data.length }
 					arrayOption={ [[ "size", 'all', ' ']] }
 				/>
 				<Link  to="/listTransactions"><button  disabled={this.state.verifyDisabled} style = {fieldProps.button} onClick={this.loadTransactionsIntoStore.bind(this)} className="btn btn-primary" type="button">Select</button></Link>
 			   </div>);
 			}
-			
+
 			let panelHeader = (<div><div style={fieldProps.panelHeader}>Backchain Verify</div></div>);
-			
+
 			let panelBody = (<div>
 								<Row style={fieldProps.panelBodyTitle}>Search by Business Transaction</Row><br/>
 								<Row style={fieldProps.panelPadding}>
@@ -175,36 +175,36 @@ const Header = ['',"Model Type", "Business Transaction ID" ];
 								</Row>
 								{tablePanel}
 							</div>);
-	
+
 			return (<div className={"panel panel-default"} onClick={this.props.action}>
 					<HeaderView store={this.props.store}/>
 						<div className={"panel-body"} style={fieldProps.panelBody}>
 							<div>
 								<Row>
-									<Col md={2} style={{paddingLeft:'37px'}}>  
-										<img src="/images/business-transaction-search.png" /> 
+									<Col md={2} style={{paddingLeft:'37px'}}>
+										<img src="/images/business-transaction-search.png" />
 									</Col>
-									<Col md={10} style={{paddingLeft:'0px', paddingTop: '13px'}}> 
+									<Col md={10} style={{paddingLeft:'0px', paddingTop: '13px'}}>
 										<span style={fieldProps.nameSpan}>
-											<strong style={fieldProps.nameColor}> 
+											<strong style={fieldProps.nameColor}>
 												Business Transaction Search
-											</strong> 
+											</strong>
 										</span> <br/>
 										<span style={fieldProps.subNameSpan}>
 											This search is a free form search that returns all transactions associated with a Business Transaction. . This search will require the transactions to be existing in the local repository.
 										</span>
 									</Col>
-								</Row> 
+								</Row>
 								<hr style={fieldProps.blankLine}/>
 							</div>
-							 
-							<Row style={fieldProps.panelBodyTitle}> 
+
+							<Row style={fieldProps.panelBodyTitle}>
 								<div> <span style={fieldProps.browse}> Search by entering a business transaction  </span>  </div>
 							 	<br/>
 								<FormControl type="text"   style={fieldProps.inputBox} onKeyPress={this.businessTransactionTextSearch.bind(this)}  onChange={this.businessTransactionTextSearch.bind(this)} placeholder="Business Transaction"  /><br/>
 							</Row>
 							{tablePanel}
-							 
+
 						</div>
 					</div>
 			);

--- a/server/es6/components/TrackAndVerifyView.jsx
+++ b/server/es6/components/TrackAndVerifyView.jsx
@@ -14,13 +14,13 @@ const verifyImgProgressing = "/images/verify-progressing.png";
 const verifyImgVerified = "/images/verify-succeded.png";
 const verifyImgFailed = "/images/verify-failed.png";
 @observer export default class TrackAndVerifyView extends React.Component {
-	constructor(props) {
+    constructor(props) {
         super(props);
     }
-    
+
     calculateVerifyImgLeftPosition() {
         if(this.props.store.verificationStatus.totalCompleted <= 97) {
-            return this.props.store.verificationStatus.totalCompleted - 1; 
+            return this.props.store.verificationStatus.totalCompleted - 1;
         } else {
             return 96;
         }
@@ -37,13 +37,22 @@ const verifyImgFailed = "/images/verify-failed.png";
     }
 
     render() {
+        const progressBar = !this.props.hideProgressBar ? (
+            <div>
+                <ProgressBar now={this.props.store.verificationStatus.totalCompleted} />
+                <img src={this.getProgressBarImg()} style={{
+                    position : 'relative',
+                    top: -58,
+                    transition: 'left .6s ease',
+                    left: this.calculateVerifyImgLeftPosition()  + '%'
+                }} />
+            </div>
+        ) : null;
+
         return (
             <div>
-                <div>
-                    <ProgressBar now={this.props.store.verificationStatus.totalCompleted} />
-                    <img src={this.getProgressBarImg()} style={{position : 'relative', top: -58, transition: 'left .6s ease', left: this.calculateVerifyImgLeftPosition()  + '%'}}/>
-                </div>
-                <TransctionsTable store = {this.props.store} />
+                {progressBar}
+                <TransctionsTable store={this.props.store} />
             </div>
 		);
     }
@@ -66,13 +75,13 @@ const verifyImgFailed = "/images/verify-failed.png";
             } else if(!rowState || rowState == 'verifying') {
                 succeded = false;
             }
-        });        
+        });
         if(failed) {
             return <i style={{marginRight: '15px', fontSize: '15px', verticalAlign: 'top', color: '#d9443f'}} className="fa fa-exclamation-circle " aria-hidden="true" />;
         } else if(succeded) {
             return <i style={{marginRight: '15px', fontSize: '15px', verticalAlign: 'top', color: '#229978'}} className="fa fa-check-circle" aria-hidden="true" />;
         } else {
-            return <i style={{marginRight: '15px', fontSize: '15px', verticalAlign: 'top', color: '#0486CC'}} className="fa fa-circle-o-notch fa-spin" aria-hidden="true" />; 
+            return <i style={{marginRight: '15px', fontSize: '15px', verticalAlign: 'top', color: '#0486CC'}} className="fa fa-circle-o-notch fa-spin" aria-hidden="true" />;
         }
     }
 
@@ -83,7 +92,7 @@ const verifyImgFailed = "/images/verify-failed.png";
         BackChainActions.zipTransactionsByIds(type, partnerName, txnids.split(','),function(){
             let zip = new JSZip();
             let file = zip.file("payload.json", JSON.stringify(payload));
-            
+
             file.generateAsync({
                 type: "blob"
             }).then(function(blob) {
@@ -113,13 +122,13 @@ const verifyImgFailed = "/images/verify-failed.png";
             downArrow : {
                 position: 'absolute',
                 marginLeft: '3px'
-            },         
+            },
         };
-        
+
         const myViewLabel = 'My View';
         let myEntName = this.props.store.entNameOfLoggedUser;
         let transactionsToVerify = [], views = [];
-        
+
         if(this.props.store.transactions.length > 0) {
             let variableViewNames = [];
             variableViewNames = Object.keys(this.props.store.viewsMap);
@@ -143,10 +152,10 @@ const verifyImgFailed = "/images/verify-failed.png";
                         }
 
                     if(transactionslice.type == "Enterprise") {
-                       
+
                         let transactionDetails = {
                             transactionId : transaction['id'],
-                            myEntName : myEntName, 
+                            myEntName : myEntName,
                             transactionSliceType : transactionslice.type
                         }
                         for(let k = 0; k < transactionslice.businessTransactions.length; k++) {
@@ -158,7 +167,7 @@ const verifyImgFailed = "/images/verify-failed.png";
                             }
                             else {
                             eventList.push(<li key={i+j+k}><span style={{color:'#990000'}}>{date}</span><br></br><span>{actionName}</span></li>);
-                            }  
+                            }
                         }
                         viewsTransactions.push(
                             <td key = {transaction['id'] + myViewLabel} txnid = {transaction['id']} style={fieldProps.columns}>
@@ -173,13 +182,13 @@ const verifyImgFailed = "/images/verify-failed.png";
                         if(this.props.store.isInitialSyncDone == null || this.props.store.isInitialSyncDone == false) {
                             partnerEntName =  transactionslice.enterprises[0] +" & "+ transactionslice.enterprises[1];
                         }
-                         
+
                         for(let k = 0; k < variableViewNames.length; k++) {
                             if(variableViewNames[k] == partnerEntName) {
                                 partnerEntName = logInUserEntIndex == 0 ?  transactionslice.enterprises[1] : transactionslice.enterprises[0];
                                 let transactionDetails = {
                                     transactionId : transaction['id'],
-                                    partnerEntName : partnerEntName, 
+                                    partnerEntName : partnerEntName,
                                     transactionSliceType : transactionslice.type
                                 }
 
@@ -195,7 +204,7 @@ const verifyImgFailed = "/images/verify-failed.png";
                         }
                     }
                 }
-                    
+
                 /* Don't draw downArrow for last row */
                 if(i != this.props.store.transactions.length - 1) {
                     downArrow =  <div style={fieldProps.downArrow}>
@@ -223,7 +232,7 @@ const verifyImgFailed = "/images/verify-failed.png";
                 }
 
                 transactionsToVerify.push(
-                    <tr style = {{backgroundColor : i%2 ? 'rgba(250, 250, 250, 1)' : ''}} key={transaction['id']}> 
+                    <tr style = {{backgroundColor : i%2 ? 'rgba(250, 250, 250, 1)' : ''}} key={transaction['id']}>
                         <td style={{maxWidth: ' 154px',padding: '10px', fontSize: '12px', verticalAlign: 'top'}}>
                                 <div style={{display: 'inline-flex'}}>
                                     <i style={{color: '#229978', fontSize: '14px'}} className="fa fa-handshake-o" aria-hidden="true"/>&nbsp;&nbsp;&nbsp;
@@ -234,18 +243,18 @@ const verifyImgFailed = "/images/verify-failed.png";
                         <td style={fieldProps.columns}>{transaction['date']}</td>
                         <td style={Object.assign({},fieldProps.columns, {cursor:'pointer'})}>
                         <div>
-                            <OverlayTrigger rootClose trigger="click" placement="right" 
+                            <OverlayTrigger rootClose trigger="click" placement="right"
                             overlay={<Popover id= {i} arrowOffsetTop = '50' title={<span><img style={{width: '18px',height:'18px'}} src="../images/event.svg"/>&nbsp;&nbsp;Events:</span>}>
                                 <ul style={{paddingLeft: '0px',listStyleType: 'none'}}>
                                     <Scrollbars style={{ width: 223, height: (eventList.length * 18 > 200 ? 200 : eventList.length * 18) }}>
                                         {eventList}
                                     </Scrollbars>
                                 </ul>
-                            </Popover>}> 
+                            </Popover>}>
                             <img style={{width: '30px',height:'26px'}} src="../images/event-badge.svg"/>
                             </OverlayTrigger>
-                            <div className = {eventCountCss}>{eventCount}</div> 
-                            </div>  
+                            <div className = {eventCountCss}>{eventCount}</div>
+                            </div>
                         </td>
                         <td style={fieldProps.columns}>{displayExecutingUsers}</td>
                         {viewsTransactions}
@@ -254,7 +263,7 @@ const verifyImgFailed = "/images/verify-failed.png";
                 }
             }
         }
-        
+
         for(let key in this.props.store.viewsMap) {
             let circleIcon = '';
             let divStyle = {paddingTop: '7px'};
@@ -276,7 +285,7 @@ const verifyImgFailed = "/images/verify-failed.png";
                 <i type={type} partnername={key} txnids={this.props.store.viewsMap[key].join()} style = {{color: '#646464', cursor:'pointer'}} className="fa fa-file-archive-o" aria-hidden="true" onClick={this.downloadZip.bind(this, this.props.store.payload)}/></div>
             </th>);
         }
-        
+
 
         let tableHead = (
             <thead style={fieldProps.tableHeader}>
@@ -299,7 +308,7 @@ const verifyImgFailed = "/images/verify-failed.png";
 		return(
             <div>
                 <TransactionPreview store={this.props.store}/>
-                <Table responsive condensed hover style={fieldProps.table}> 
+                <Table responsive condensed hover style={fieldProps.table}>
                     {tableHead}
                     {tableBody}
                 </Table>
@@ -320,7 +329,7 @@ const verifyImgFailed = "/images/verify-failed.png";
             previewComponent = <DiffView store= {this.props.store}/>
         }
         return(<Modal dialogClassName = {dialogClassName} show={this.props.store.myAndDiffViewModalActive} onHide={BackChainActions.toggleMyAndDiffView}>
-                {previewComponent} 
+                {previewComponent}
                </Modal>);
     }
 }
@@ -343,7 +352,7 @@ const ViewOrDownloadTxn = (props) => {
             return <i style={{marginRight: '15px', fontSize: '15px', verticalAlign: 'top', color: '#229978'}} className="fa fa-check-circle" aria-hidden="true" />;
         }
     }
-    
+
     function storeTransactions(event) {
         BackChainActions.toggleMyAndDiffView();
         BackChainActions.loadViewTransactionsById(transactionSliceType, partnerEntName, event.currentTarget.getAttribute('txnid').split(','));
@@ -358,7 +367,7 @@ const ViewOrDownloadTxn = (props) => {
     return(
         <div>
             {getVerificationIcon()}&nbsp;&nbsp;
-            <OverlayTrigger rootClose trigger="click" placement="right" 
+            <OverlayTrigger rootClose trigger="click" placement="right"
                 overlay={<Popover id={transactionId + entNameForViwe} style = {{width: '100px', fontWeight: '600', padding: '5px', lineHeight: '25px', zIndex: '0'}}>
                             <Row txnid = {transactionId} onClick={storeTransactions.bind(this)} style = {{color: 'rgba(45, 162, 191, 1)', cursor:'pointer'}}>
                                 <Col md={1}>

--- a/server/es6/components/TrackAndVerifyView.jsx
+++ b/server/es6/components/TrackAndVerifyView.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Row, Button, Panel, Checkbox, Table, Col, OverlayTrigger, Popover, ProgressBar, Modal} from 'react-bootstrap';
+import { toJS } from 'mobx';
 import MyView from './MyView';
 import DiffView from './DiffView';
 import BackChainActions from '../BackChainActions';
@@ -138,30 +139,32 @@ const verifyImgFailed = "/images/verify-failed.png";
             }
 
             let eventCountCss = "counter3";
-            for (let i = 0; i < this.props.store.transactions.length; i++) {
-                let transaction = this.props.store.transactions[i];
+            const transactions = toJS(this.props.store.transactions);
+            for (let i = 0; i < transactions.length; i++) {
+                let transaction = transactions[i];
                 let executingUsers = [], viewsTransactions = [], downArrow = '', eventCount = null, eventList = [];
                 if(transaction){
-                for(let j = 0; j < transaction.transactionSliceObjects.length; j++) {
-                    let transactionslice = transaction.transactionSliceObjects[j];
-                        eventCount = transactionslice.businessTransactions.length;
-                        if(eventCount.toString().length == 1) {
-                            eventCountCss =  "counter1";
-                        } else if(eventCount.toString().length == 2) {
-                            eventCountCss =  "counter2";
-                        }
-
-                    if(transactionslice.type == "Enterprise") {
-
+                for(let j = 0; j < transaction.transactionSlices.length; j++) {
+                    let transactionSlice = transaction.transactionSlices[j];
+                    /*
+                    let eventCount = transactionSlice.businessTransactions.length;
+                    if(eventCount.toString().length == 1) {
+                        eventCountCss =  "counter1";
+                    } else if(eventCount.toString().length == 2) {
+                        eventCountCss =  "counter2";
+                    }
+                    */
+                    if(transactionSlice.type == "Enterprise") {
                         let transactionDetails = {
                             transactionId : transaction['id'],
                             myEntName : myEntName,
-                            transactionSliceType : transactionslice.type
+                            transactionSliceType : transactionSlice.type
                         }
-                        for(let k = 0; k < transactionslice.businessTransactions.length; k++) {
-                            executingUsers.push(transactionslice.businessTransactions[k].LastModifiedUser);
-                            let date = transactionslice.businessTransactions[k].LastModifiedDate.date;
-                            let actionName = transactionslice.businessTransactions[k].ActionName.split('.')[1];
+                        /*
+                        for(let k = 0; k < transactionSlice.businessTransactions.length; k++) {
+                            executingUsers.push(transactionSlice.businessTransactions[k].LastModifiedUser);
+                            let date = transactionSlice.businessTransactions[k].LastModifiedDate.date;
+                            let actionName = transactionSlice.businessTransactions[k].ActionName.split('.')[1];
                             if(date.toString().length + actionName.length < 29) {
                                 eventList.push(<li key={i+j+k}><span style={{color:'#990000',display:'inline'}}>{date}</span> <span style={{display:'inline'}}>&nbsp;&nbsp;&nbsp;{actionName}</span></li>);
                             }
@@ -169,27 +172,27 @@ const verifyImgFailed = "/images/verify-failed.png";
                             eventList.push(<li key={i+j+k}><span style={{color:'#990000'}}>{date}</span><br></br><span>{actionName}</span></li>);
                             }
                         }
+                        */
                         viewsTransactions.push(
                             <td key = {transaction['id'] + myViewLabel} txnid = {transaction['id']} style={fieldProps.columns}>
                                 <ViewOrDownloadTxn store = {this.props.store} downloadZip = {this.downloadZip}  transactionDetails = {transactionDetails} />
                             </td>
                         );
                     }
-
-                    if(transactionslice.type == "Intersection") {
-                        let logInUserEntIndex = (transactionslice.enterprises).indexOf(myEntName);
-                        let partnerEntName = logInUserEntIndex == 0 ?  transactionslice.enterprises[1] : transactionslice.enterprises[0];
+                    else if(transactionSlice.type == "Intersection") {
+                        let logInUserEntIndex = (transactionSlice.enterprises).indexOf(myEntName);
+                        let partnerEntName = logInUserEntIndex == 0 ?  transactionSlice.enterprises[1] : transactionSlice.enterprises[0];
                         if(this.props.store.isInitialSyncDone == null || this.props.store.isInitialSyncDone == false) {
-                            partnerEntName =  transactionslice.enterprises[0] +" & "+ transactionslice.enterprises[1];
+                            partnerEntName =  transactionSlice.enterprises[0] +" & "+ transactionSlice.enterprises[1];
                         }
 
                         for(let k = 0; k < variableViewNames.length; k++) {
                             if(variableViewNames[k] == partnerEntName) {
-                                partnerEntName = logInUserEntIndex == 0 ?  transactionslice.enterprises[1] : transactionslice.enterprises[0];
+                                partnerEntName = logInUserEntIndex == 0 ?  transactionSlice.enterprises[1] : transactionSlice.enterprises[0];
                                 let transactionDetails = {
                                     transactionId : transaction['id'],
                                     partnerEntName : partnerEntName,
-                                    transactionSliceType : transactionslice.type
+                                    transactionSliceType : transactionSlice.type
                                 }
 
                                 viewsTransactions.push(

--- a/server/es6/config.js
+++ b/server/es6/config.js
@@ -1,4 +1,4 @@
-module.exports = {syncDataIntervalInMillis : 60000,
+module.exports = {syncDataIntervalInMillis : 5000,
                   chainOfCustodyUrl: 'http://localhost',
                   blockChainUrl:  'http://192.168.201.55:8545',
                   blockChainContractAddress:'0xc5d4b021858a17828532e484b915149af5e1b138',

--- a/server/es6/store/BackChainStore.jsx
+++ b/server/es6/store/BackChainStore.jsx
@@ -44,50 +44,56 @@ class BackChainStore {
         /* viewsMap contains all viewnames with corresponding transaction ids */
         this.transactions.forEach(transaction => {
             if (transaction) {
-                for (let j = 0; j < transaction.transactionSliceObjects.length; j++) {
-                    let transactionslice = transaction.transactionSliceObjects[j];
-                    // myView 
-                    if(transactionslice.type == "Enterprise") {
+                for (let j = 0; j < transaction.transactionSlices.length; j++) {
+                    let transactionSlice = transaction.transactionSlices[j];
+                    // myView
+                    if(transactionSlice.type == "Enterprise") {
                         if(this.isInitialSyncDone == null || this.isInitialSyncDone == false) {
-                            if (transactionslice.enterprise in viewsMap) {
-                                viewsMap[transactionslice.enterprise].push(transaction.id);
-                                viewsMap[transactionslice.enterprise] = Array.from(new Set(viewsMap[transactionslice.enterprise]));
-                            } else {
-                                viewsMap[transactionslice.enterprise] = [transaction.id];
+                            if (transactionSlice.enterprise in viewsMap) {
+                                viewsMap[transactionSlice.enterprise].push(transaction.id);
+                                viewsMap[transactionSlice.enterprise] = Array.from(new Set(viewsMap[transactionSlice.enterprise]));
                             }
-                            this.entNameOfLoggedUser = transactionslice.enterprise; /***/
-                        } else if (transactionslice.enterprise == myEntName) {
+                            else {
+                                viewsMap[transactionSlice.enterprise] = [transaction.id];
+                            }
+                            this.entNameOfLoggedUser = transactionSlice.enterprise; /***/
+                        }
+                        else if (transactionSlice.enterprise == myEntName) {
                             if (myEntName in viewsMap) {
                                 viewsMap[myEntName].push(transaction.id);
                                 viewsMap[myEntName] = Array.from(new Set(viewsMap[myEntName]));
-                            } else {
+                            }
+                            else {
                                 viewsMap[myEntName] = [transaction.id];
                             }
                         }
                     }
                     // intersection
-                    if(transactionslice.type == "Intersection") {
+                    else if(transactionSlice.type == "Intersection") {
                         if(this.isInitialSyncDone == null || this.isInitialSyncDone == false) {
-                            let partnerEntName =  transactionslice.enterprises[0] +" & "+ transactionslice.enterprises[1];
-                            
+                            let partnerEntName =  transactionSlice.enterprises[0] +" & "+ transactionSlice.enterprises[1];
+
                             if (partnerEntName in viewsMap) {
                                 viewsMap[partnerEntName].push(transaction.id);
                                 viewsMap[partnerEntName] = Array.from(new Set(viewsMap[partnerEntName]));
-                            } else {
+                            }
+                            else {
                                 viewsMap[partnerEntName] = [transaction.id];
                             }
-                        } else if (((transactionslice.enterprises).indexOf(myEntName) > -1)) {
-                                let logInUserEntIndex = (transactionslice.enterprises).indexOf(myEntName);
-                                let partnerEntName = logInUserEntIndex == 0 ? transactionslice.enterprises[1] : transactionslice.enterprises[0];
+                        }
+                        else if (((transactionSlice.enterprises).indexOf(myEntName) > -1)) {
+                            let logInUserEntIndex = (transactionSlice.enterprises).indexOf(myEntName);
+                            let partnerEntName = logInUserEntIndex == 0 ? transactionSlice.enterprises[1] : transactionSlice.enterprises[0];
 
-                                if (partnerEntName in viewsMap) {
-                                    viewsMap[partnerEntName].push(transaction.id);
-                                    viewsMap[partnerEntName] = Array.from(new Set(viewsMap[partnerEntName]));
-                                } else {
-                                    viewsMap[partnerEntName] = [transaction.id];
-                                }
+                            if (partnerEntName in viewsMap) {
+                                viewsMap[partnerEntName].push(transaction.id);
+                                viewsMap[partnerEntName] = Array.from(new Set(viewsMap[partnerEntName]));
+                            }
+                            else {
+                                viewsMap[partnerEntName] = [transaction.id];
                             }
                         }
+                    }
                 }
             }
         });
@@ -108,12 +114,12 @@ class BackChainStore {
     }
 
     /**
-     * Returns 
+     * Returns
      * {
      *      totalCompleted: percentage of the verification process
      *      endResult: verifying, failed, succeeded
      * }
-     * 
+     *
      */
     @computed get verificationStatus() {
         let totalCompleted = 0;
@@ -121,7 +127,7 @@ class BackChainStore {
         if(this.canStartVerifying) {
             let i = 0;
             const totalCnt = this.verifications.keys().length;
-            let completedCnt = 0; 
+            let completedCnt = 0;
             let failed = false;
             let completed = false;
             this.verifications.forEach(value => {
@@ -131,7 +137,7 @@ class BackChainStore {
                 }
                 if(value == 'verified') {
                     completedCnt++;
-                } 
+                }
             });
             completed = (completedCnt == totalCnt);
             if(failed) {

--- a/server/index.html
+++ b/server/index.html
@@ -10,8 +10,8 @@
     <link rel="stylesheet" type="text/css" href="css/diffview.css">
     <script src="http://code.jquery.com/jquery-2.1.3.min.js"></script>
     <script src="js/jquery.json-viewer.js"></script>
-    <link rel="stylesheet" type="text/css" href="./css/jquery.json-viewer.css">	
-    <link rel="stylesheet" type="text/css" href="./css/style.css">	
+    <link rel="stylesheet" type="text/css" href="./css/jquery.json-viewer.css">
+    <link rel="stylesheet" type="text/css" href="./css/style.css">
 
     <style>
         body {
@@ -23,5 +23,8 @@
 <div id="root" class="container"></div>
 <script src="dist/libs.js"></script>
 <script src="dist/bundle.js"></script>
+<script type="application/javascript">
+    BackchainVerifyAPI.setup('#root');
+</script>
 </body>
 </html>


### PR DESCRIPTION
This PR is part 1 of refactoring BCV to support the CoC page (changes made on behalf of bezrodnov) and better support large amounts of data without running into memory issues.

As part of the refactoring, the structure of the `Transactions` collection in the DB has to change. This is the current planned structure, although the final version may change slightly:

```
transactions: [{
  id,
  date,
  transactionSlices: [{
    type,
    enterprise/enterprises,
    sequence,
    payloadId,
    businessTransactionIds: [ ... ]
  }, ... ],
  transactionSliceHashes: [ ... ],
  trueTransactionSliceHashes: [ ... ]
}]
```

Notable changes:
 * `payloadId` is a unique id to the serialized slice data, which will be stored in Mongo's GridFS system.
 * `trueTransactionSliceHashes` represents the array of serialized slice data that has been hashed by BCV, while `transactionSliceHashes` holds the hashes sent by Platform via the `rest/backchain/consume` API.
 * When verifying data for display in the UI, the logic checks whether the hash sent by Platform is equivalent to the one generated by BCV, and also checks the Backchain for the hash. The hash is verified if it passes both of these checks.