### PR TITLE
Add support for downloading attachments from PLT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 log/
 node_modules/
+attachments/
 server/es5/
 server/public/dist/
 package.json

--- a/server/es6/BackChainUtil.js
+++ b/server/es6/BackChainUtil.js
@@ -4,13 +4,22 @@
 class BackChainUtil {
     constructor() {}
 
-    /*checks if url contains http or https. If not it returns by appending http*/
-    returnValidURL(url) {
+    // Adds http:// to the url if it doesn't contain a protocol,
+    // and optionally adds parameters to the URL if cfg is supplied.
+    returnValidURL(url, cfg) {
         var matchProtocol = new RegExp("^(http|https)://", "i");
         if(!matchProtocol.test(url)) {
             url = "http://" + url;
         }
-        console.log(url);
+
+        if(cfg) {
+            for(let paramName in cfg) {
+                let sepChar = url.indexOf('?') < 0 ? '?' : '&';
+                url += sepChar + encodeURIComponent(paramName) + '=' + encodeURIComponent(cfg[paramName]);
+            }
+        }
+
+        console.log(' > Url: ' + url);
         return url;
     }
 


### PR DESCRIPTION
Attachments are automatically downloaded if available for any
business transaction. They are all stored by unique filepath on
the filesystem, in `attachments/`.